### PR TITLE
feat: add functions for translate from ru to en and en to ru

### DIFF
--- a/src/app/common/constants.js
+++ b/src/app/common/constants.js
@@ -1,4 +1,11 @@
-/* eslint-disable import/prefer-default-export */
 export const DEFAULT_SESSION_DATA = Object.freeze({
   score: 0,
+});
+
+export const API_KEYS = Object.freeze({
+  yandexTranslation: 'trnsl.1.1.20200421T084156Z.8eb8c0246fffb61e.780bc9f73b105718a88f1ccd7658c5b3005b7921',
+});
+
+export const API_REQUEST = Object.freeze({
+  yandexTranslation: 'https://translate.yandex.net/api/v1.5/tr.json/translate?',
 });

--- a/src/app/common/index.js
+++ b/src/app/common/index.js
@@ -9,3 +9,5 @@ export {
 export { setSessionData, getSessionData, getAndInitSessionData } from './utils/sessionStorage';
 
 export { wordInfo, partOfSpeech } from './network/wordsApi/apiWords';
+
+export { translateEngToRus, translateRusToEng } from './network/translationAPI';

--- a/src/app/common/network/basicFetch.js
+++ b/src/app/common/network/basicFetch.js
@@ -1,0 +1,10 @@
+export default async function basicFetch(url, options) {
+  try {
+    const response = await fetch(url, options);
+    const content = (response.status === 200) ? await response.json() : null;
+    return content;
+  } catch (error) {
+    console.warn(error);
+    return null;
+  }
+}

--- a/src/app/common/network/translationAPI.js
+++ b/src/app/common/network/translationAPI.js
@@ -1,0 +1,22 @@
+import { API_KEYS, API_REQUEST } from '../constants';
+import basicFetch from './basicFetch';
+
+export const translateEngToRus = async (word, key = 'yandexTranslation') => {
+  const url = `${API_REQUEST.yandexTranslation}key=${API_KEYS[key]}&text=${word}&lang=en-ru`;
+
+  const yandexResponse = await basicFetch(url);
+
+  const translate = yandexResponse ? yandexResponse.text[0] : null;
+
+  return translate;
+};
+
+export const translateRusToEng = async (word, key = 'yandexTranslation') => {
+  const url = `${API_REQUEST.yandexTranslation}key=${API_KEYS[key]}&text=${word}&lang=ru-en`;
+
+  const yandexResponse = await basicFetch(url);
+
+  const translate = yandexResponse ? yandexResponse.text[0] : null;
+
+  return translate;
+};


### PR DESCRIPTION
Добавил две async функции для перевода:
```
translateEngToRus(word, key)
translateRusToEng(word, key)
```

На вход два параметра: слово и имя свойства (в вид строки) объекта API_KEYS из модуля constants.js, в качестве значения содержащие ваш ключ от Yandex.Transate API.

Создателям игр рекомендуется добавлять свои ключи в constants.js и пользоваться в игре им. Особенно если в игре множество запросов перевода.
![constant](https://user-images.githubusercontent.com/33804591/85217425-90dd1e80-b399-11ea-8803-4e6947aa9c89.jpg)

На выходе строка с переводом.
