### PR TITLE
Feat/add menu click handler

### DIFF
--- a/src/app/common/controls/controls.js
+++ b/src/app/common/controls/controls.js
@@ -1,0 +1,16 @@
+import menuHandlers from './menuHandlers';
+
+export default function menuClickHandler() {
+  document.querySelector('.menu').addEventListener('click', (event) => {
+    const el = event.target.closest('.menu__items__item');
+    if (el) {
+      const functionName = el.dataset.handler;
+      if (functionName !== undefined) {
+        menuHandlers[functionName]();
+      } else {
+        // eslint-disable-next-line no-alert
+        alert('эта страница еще не создана');
+      }
+    }
+  });
+}

--- a/src/app/common/controls/menuHandlers.js
+++ b/src/app/common/controls/menuHandlers.js
@@ -1,0 +1,3 @@
+import renderSettings from '../../main/settings/index';
+
+export default { renderSettings };

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,7 @@
 import menuHandling from './app/main/menu/menu';
+import menuClickHandler from './app/common/controls/controls';
 
 window.onload = () => {
   menuHandling();
+  menuClickHandler();
 };


### PR DESCRIPTION
добавила eventListener для клика по пунктам меню. Например, если кликаешь на settings в меню, вызывалась функция renderSettings();
Вот как я это реализовала:

- В элементы меню в HTML я добавила data-handler="". На данный момент добавила только для страницы settings, так как она уже реализована - data-handler="renderSettings". В дальнейшем каждый будет добавлять свой data-handler самостоятельно. Его имя должно быть такое же как имя функции для рендеринга этой страницы.
![image](https://user-images.githubusercontent.com/10921996/86101941-99cd9e80-bac3-11ea-820e-a74697611817.png)

- в файле app/common/controls/menuHandlers.js я импортировала и экспортировала функцию renderSettings(); menuHandlers.js - это будет наш унифицированный файл со всеми хендлерами; То есть, когда вы создаете страницу и функцию для ее рендеринга, например renderAboutUs(), то вы должны также импортировать/экспортировать ее в этот файл.
![image](https://user-images.githubusercontent.com/10921996/86102160-d7322c00-bac3-11ea-860d-7461766b4188.png)

- затем, в app/controls/controls.js я написала функцию, которая обрабатывает клик на элементе меню, берет название data-handler и вызывает соответствующую одноименную функцию. Если такой функции еще нет, то выводится сообщение.
![image](https://user-images.githubusercontent.com/10921996/86102298-ffba2600-bac3-11ea-81a8-0fbefc6f8094.png)
все функции я беру из импортированного файла описанного выше import menuHandlers from './menuHandlers';

- затем импортирую controls.js в main.js и вызываю menuClickHandler();
![image](https://user-images.githubusercontent.com/10921996/86102432-31cb8800-bac4-11ea-8c90-b9f586076ffd.png)


